### PR TITLE
add transportation profile configuration (car, foot, bicycle)

### DIFF
--- a/osrm/files/http-extract.sh.tpl
+++ b/osrm/files/http-extract.sh.tpl
@@ -15,11 +15,12 @@ ensure_dependency osrm-customize
 version="{{ .Values.map.http.version | default "unversioned" }}"
 file_pbf="map.osm.pbf"
 file_osrm="map.osrm"
+profile="{{ .Values.map.profile }}"
 
 cd "/data/maps/${version}"
 
 if [ ! -r extracted.lock ]; then
-  osrm-extract -p /opt/car.lua "${file_pbf}"
+  osrm-extract -p /opt/${profile}.lua "${file_pbf}"
   osrm-partition "${file_osrm}"
   osrm-customize "${file_osrm}"
 

--- a/osrm/values.yaml
+++ b/osrm/values.yaml
@@ -123,6 +123,10 @@ map:
   # set this to false.
   enabled: true
 
+  # The transportation profile used for the release.
+  # For now, the only supported profiles are the default OSRM profiles: car (default), bicycle, foot
+  profile: car
+
   # Configures what source provider to use to download map.
   # Supported providers:
   # - http


### PR DESCRIPTION
Hi,

I am adding support for configuring the transportation profile through the chart.
The extraction script uses the profile setting in `.Values.map.profile` to perform the extraction for the correct profile.